### PR TITLE
Simplify tag code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use the templatetag in your base.html
 ```html+django
 {% load favtags %}
     
-{% autoescape off %}{% placeFavicon %}{% endautoescape %}
+{% placeFavicon %}
 ```
 this will create:
 ```html

--- a/favicon/templatetags/favtags.py
+++ b/favicon/templatetags/favtags.py
@@ -1,9 +1,7 @@
 from django import template
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from django.utils.safestring import mark_safe
 
-from favicon.models import Favicon
-from favicon.models import config
+from favicon.models import Favicon, config
 
 register = template.Library()
 
@@ -18,35 +16,10 @@ def placeFavicon(context):
         {% placeFavicon %}
 
     """
-    fav = Favicon.objects.filter(isFavicon=True)
+    fav = Favicon.objects.filter(isFavicon=True).first()
     if not fav:
         return '<!-- no favicon -->'
-    for n in fav[1:]:
-        n.isFavicon = False
-    fav = fav[0]
-    '''
-    if a:
-        fav = a[0]
-    else:
-        return '<!-- %s -->' % ('no favicon found',)
-    '''
-    favs = fav.get_favicons()
-    request = context['request']
     html = ''
-    #html += '<link rel="shortcut icon" href="http://%s/favicon.ico"/>' % (request.get_host(),)
-    #html += '<link rel="shortcut icon" href="http://%s/favicon.ico"/>'
-
-    '''
-    for rel in config:
-        for size in sorted(config[rel], reverse=True)[:-1]:
-            n = fav.get_favicon(size=size, rel=rel)
-            html += '<link rel="%s" size ="%sx%s" href="%s%s"/>' % (
-                n.rel, n.size, n.size, media_url, n.faviconImage.name)
-        for size in sorted(config[rel], reverse=True)[-1:]:
-            n = fav.get_favicon(size=size, rel=rel)
-            html += '<link rel="%s" size ="any" href="%s%s"/>' % (
-                n.rel, media_url, n.faviconImage.name)
-    '''
     for rel in config:
         for size in sorted(config[rel], reverse=True):
             n = fav.get_favicon(size=size, rel=rel)
@@ -57,4 +30,4 @@ def placeFavicon(context):
     html += '<link rel="%s" size ="%sx%s" href="%s"/>' % (
         default_fav.rel, default_fav.size, default_fav.size, default_fav.faviconImage.url)
 
-    return html
+    return mark_safe(html)


### PR DESCRIPTION
I encountered a bug with django-favicon-plus : when rendering a django 50x error view, I got an error due to `context['request']` call. In that case, the context is mostly empty so it raised an error during treating an error.

I found out this line was useless, so I removed it. I also removed unused imports and all commented code (didn't know if it was dead code or something experimental...).

I simplified the `fav` finding by using `.first()` in the queryset.

At the end, I also added a `mark_safe` call in order to avoid to use `autoescape` tags around `placeFavicon`.