### PR TITLE
Set proper link attribute 'sizes' in templatetag

### DIFF
--- a/favicon/templatetags/favtags.py
+++ b/favicon/templatetags/favtags.py
@@ -23,11 +23,11 @@ def placeFavicon(context):
     for rel in config:
         for size in sorted(config[rel], reverse=True):
             n = fav.get_favicon(size=size, rel=rel)
-            html += '<link rel="%s" size ="%sx%s" href="%s"/>' % (
+            html += '<link rel="%s" sizes="%sx%s" href="%s"/>' % (
                 n.rel, n.size, n.size, n.faviconImage.url)
 
     default_fav = fav.get_favicon(size=32, rel='shortcut icon')
-    html += '<link rel="%s" size ="%sx%s" href="%s"/>' % (
+    html += '<link rel="%s" sizes="%sx%s" href="%s"/>' % (
         default_fav.rel, default_fav.size, default_fav.size, default_fav.faviconImage.url)
 
     return mark_safe(html)


### PR DESCRIPTION
There seems to be a typo in the templatetag generator on lines 26 and 30.

The attribute 'sizes=' written as 'size ='. This break w3c tests as that attribute is not available in the link tag.