### PR TITLE
#24 fixed bug at python 3.8.5 and django 3.0.11

### DIFF
--- a/favicon/models.py
+++ b/favicon/models.py
@@ -1,5 +1,3 @@
-from compat import python_2_unicode_compatible
-
 import sys
 
 from django.db import models
@@ -24,7 +22,6 @@ def pre_delete_image(sender, instance, **kwargs):
     instance.del_image()
 
 
-@python_2_unicode_compatible
 class Favicon(models.Model):
 
     title = models.CharField(max_length=100)


### PR DESCRIPTION
At python 3.8.5 and django 3.0.11 i found an error after try creation Favicon model:
```
Traceback (most recent call last):
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/contrib/admin/options.py", line 607, in wrapper
    return self.admin_site.admin_view(view)(*args, **kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/contrib/admin/sites.py", line 231, in inner
    return view(request, *args, **kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/contrib/admin/options.py", line 1638, in add_view
    return self.changeform_view(request, None, form_url, extra_context)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/utils/decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/contrib/admin/options.py", line 1522, in changeform_view
    return self._changeform_view(request, object_id, form_url, extra_context)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/contrib/admin/options.py", line 1569, in _changeform_view
    self.log_addition(request, new_object, change_message)
  File "/home/execut/.local/share/virtualenvs/PIPENV_VENV_IN_PROJECT=1/lib/python3.8/site-packages/django/contrib/admin/options.py", line 807, in log_addition
    object_repr=str(object),

Exception Type: TypeError at /en/admin/favicon/favicon/add/
Exception Value: __str__ returned non-string (type bytes)
```
I fixed it by remove python2 compatibility @python_2_unicode_compatible tag. How do I fix it while maintaining compatibility?